### PR TITLE
Change bcrypt-ruby to bcrypt

### DIFF
--- a/casino-activerecord_authenticator.gemspec
+++ b/casino-activerecord_authenticator.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'activerecord', '~> 3.2.12'
   s.add_runtime_dependency 'unix-crypt', '~> 1.1'
-  s.add_runtime_dependency 'bcrypt-ruby', '~> 3.0'
+  s.add_runtime_dependency 'bcrypt', '~> 3.0'
   s.add_runtime_dependency 'casino', '~> 2.0'
   s.add_runtime_dependency 'phpass-ruby', '~> 0.1'
 end


### PR DESCRIPTION
The gem name has changed from bcrypt-ruby to bcrypt. Leaving bcrypt-ruby in this gemspec left CASinoApp's Gemfile.lock depending on brcypt and bcrypt-ruby.
