### PR TITLE
Remove call to deprecated `set_table_name`

### DIFF
--- a/lib/casino/activerecord_authenticator.rb
+++ b/lib/casino/activerecord_authenticator.rb
@@ -15,7 +15,7 @@ class CASino::ActiveRecordAuthenticator
 
     eval <<-END
       class #{self.class.to_s}::#{@options[:table].classify} < AuthDatabase
-        set_table_name "#{@options[:table]}"
+        self.table_name = "#{@options[:table]}"
       end
     END
 


### PR DESCRIPTION
Because ActiveRecord 3 deprecates `set_table_name`, and ActiveRecord 4
removes it, I've switched to using `#table_name=` to prepare for the
update and remove the deprecation warnings.
