### PR TITLE
Update to ActiveRecord 4

### DIFF
--- a/casino-activerecord_authenticator.gemspec
+++ b/casino-activerecord_authenticator.gemspec
@@ -23,9 +23,9 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'sqlite3', '~> 1.3.7'
   s.add_development_dependency 'coveralls'
 
-  s.add_runtime_dependency 'activerecord', '~> 3.2.12'
+  s.add_runtime_dependency 'activerecord', '~> 4.1'
   s.add_runtime_dependency 'unix-crypt', '~> 1.1'
   s.add_runtime_dependency 'bcrypt', '~> 3.0'
-  s.add_runtime_dependency 'casino', '~> 2.0'
+  s.add_runtime_dependency 'casino', '3.0.0.pre.1'
   s.add_runtime_dependency 'phpass-ruby', '~> 0.1'
 end

--- a/lib/casino/activerecord_authenticator.rb
+++ b/lib/casino/activerecord_authenticator.rb
@@ -24,7 +24,7 @@ class CASino::ActiveRecordAuthenticator
   end
 
   def validate(username, password)
-    @model.verify_active_connections!
+    @model.clear_active_connections!
     user = @model.send("find_by_#{@options[:username_column]}!", username)
     password_from_database = user.send(@options[:password_column])
 


### PR DESCRIPTION
`verify_active_connections!` was removed for Rails 4, so this commit
removes it in favor of the delegated `clear_all_connections!`.

This also adds a dependency on the pre-release of the CASino gem, but at the very least this can serve as a pre-release on this authenticator.
