### PR TITLE
Fix Single table inheritance problem

### DIFF
--- a/lib/casino/activerecord_authenticator.rb
+++ b/lib/casino/activerecord_authenticator.rb
@@ -19,6 +19,7 @@ class CASino::ActiveRecordAuthenticator
     eval <<-END
       class #{self.class.to_s}::#{@options[:table].classify} < AuthDatabase
         self.table_name = "#{@options[:table]}"
+        self.inheritance_column = :_type_disabled
       end
     END
 


### PR DESCRIPTION
This PR is to disable STI in CASINO model because when STI is used in the client application, the authenticated model that is created at runtime in CASINO expects to find the subclass but it doesn't find it.

Example: users table with a type column with the value "Customer" in any record
Error: ActiveRecord::SubclassNotFound (The single-table inheritance mechanism failed to locate the subclass: 'Customer'. This error is raised because the column 'type' is reserved for storing the class in case of inheritance. Please rename this column if you didn't intend it to be used for storing the inheritance class or overwrite CASino::ActiveRecordAuthenticator::User.inheritance_column to use another column for that information.)

So this PR is just to disable it.
