### PR TITLE
Add pessimistic Rails 4.2 support

### DIFF
--- a/casino-activerecord_authenticator.gemspec
+++ b/casino-activerecord_authenticator.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'sqlite3', '~> 1.3.7'
   s.add_development_dependency 'coveralls'
 
-  s.add_runtime_dependency 'activerecord', '~> 4.1.0'
+  s.add_runtime_dependency 'activerecord', '>= 4.1.0', '< 4.3.0'
   s.add_runtime_dependency 'unix-crypt', '~> 1.1'
   s.add_runtime_dependency 'bcrypt', '~> 3.0'
   s.add_runtime_dependency 'casino', '>= 3.0.0', '< 5.0.0'


### PR DESCRIPTION
This commit bumps the ActiveRecord dependency to match rbCAS/CASino#84.
