### PR TITLE
Support for connection string

### DIFF
--- a/lib/casino/activerecord_authenticator.rb
+++ b/lib/casino/activerecord_authenticator.rb
@@ -20,7 +20,7 @@ class CASino::ActiveRecordAuthenticator
       model_name = @options[:model_name]
     else
       model_name = @options[:table]
-      if @options[:connection][:database]
+      if @options[:connection].kind_of? Hash
         model_name = "#{@options[:connection][:database].gsub(/[^a-zA-Z]+/, '')}_#{model_name}"
       end
       model_name = model_name.classify

--- a/spec/casino_core/activerecord_authenticator_spec.rb
+++ b/spec/casino_core/activerecord_authenticator_spec.rb
@@ -19,6 +19,7 @@ describe CASino::ActiveRecordAuthenticator do
     }
   end
   let(:faulty_options){ options.merge(table: nil) }
+  let(:connection_as_string) { options.merge(connection: 'sqlite3:/tmp/casino-test-auth.sqlite') }
   let(:user_class) { described_class::TmpcasinotestauthsqliteUser }
 
   subject { described_class.new(options) }
@@ -191,6 +192,14 @@ describe CASino::ActiveRecordAuthenticator do
       it 'is able to handle phpass password hashes' do
         subject.validate('test4', 'test12345').should be_instance_of(Hash)
       end
+    end
+
+    context 'support for connection string' do
+
+      it 'should not raise an error' do
+        expect{described_class.new(connection_as_string)}.to_not raise_error
+      end
+
     end
 
   end

--- a/spec/casino_core/activerecord_authenticator_spec.rb
+++ b/spec/casino_core/activerecord_authenticator_spec.rb
@@ -200,6 +200,9 @@ describe CASino::ActiveRecordAuthenticator do
         expect{described_class.new(connection_as_string)}.to_not raise_error
       end
 
+      it 'returns the username' do
+        described_class.new(connection_as_string).load_user_data('test')[:username].should eq('test')
+      end
     end
 
   end


### PR DESCRIPTION
CASino engine seems to support connection strings, but this authenticator gave error. Not a big change, but crucial for us. 

We have an app where we're managing user registrations with devise and using CASino engine for allowing SSO authentications to other apps. App is hosted at Heroku, which is the reason why we have to use connection string.