### PR TITLE
Make ActiveRecord queries thread-safe

### DIFF
--- a/lib/casino/activerecord_authenticator.rb
+++ b/lib/casino/activerecord_authenticator.rb
@@ -53,8 +53,11 @@ class CASino::ActiveRecordAuthenticator
     }
   end
 
-  def user_data(user)
-    { username: user[@options[:username_column].to_s], extra_attributes: extra_attributes(user) }
+  def user_data(user_hash)
+    {
+      username: user_hash[@options[:username_column].to_s],
+      extra_attributes: extra_attributes(user_hash)
+    }
   end
 
   def valid_password?(password, password_from_database)
@@ -83,10 +86,10 @@ class CASino::ActiveRecordAuthenticator
     Phpass.new().check(password, password_from_database)
   end
 
-  def extra_attributes(user)
+  def extra_attributes(user_hash)
     attributes = {}
     extra_attributes_option.each do |attribute_name, database_column|
-      attributes[attribute_name] = user[database_column.to_s]
+      attributes[attribute_name] = user_hash[database_column.to_s]
     end
     attributes
   end


### PR DESCRIPTION
When using a threaded HTTP server like Puma, calling `Model.establish_connection` is dangerous. There is a chance the ActiveRecord connection is swapped by Casino itself and you'll get a `Table doesn't exist` error.  In a really bad case though, Casino and the database we are connecting to may have a `users` table of the same name which could result in incorrect data being accessed.

This PR rewrites the connection to instead rely on a `ConnectionPool` which is thread-safe. Additionally it no longer requires a class to be meta-programmed and called -- it now just runs the SQL query directly.

I will work on getting the tests to pass.